### PR TITLE
feat: Update build and pack.

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -14,15 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # - name: Setup Node
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: 14.x
+      - name: Setup .NET Environment
+        id: dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
 
-      # - name: Install Semantic-Release dependencies
-      #   run: npm install
-
-      - name: Semantic-Release
+      - name: Update and Pack the Release
         id: semantic
         uses: cycjimmy/semantic-release-action@v2
         with:
@@ -30,13 +28,20 @@ jobs:
           branches: "['main', 'next', {name: 'rc', prerelease: true}]"
           extra_plugins: |
             @semantic-release/changelog
+            @semantic-release/exec
             @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Do something when a new release published
-        if: steps.semantic.outputs.new_release_published == 'true'
+      - name: Publish Artifacts
+        id: artifacts
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: artifacts
+          path: ./artifacts/**/*.*
+          retention-days: 0
+
+      - name: Display Release Info
         run: |
-          echo New Release? ${{ steps.semantic.outputs.new_release_version }}
           echo Last Release: ${{ steps.semantic.outputs.last_release_version }}
           echo This Release: ${{ steps.semantic.outputs.new_release_version }}

--- a/.releaserc
+++ b/.releaserc
@@ -9,12 +9,18 @@
             }
         ],
         [
+            "@semantic-release/exec",
+            {
+                "successCmd": "dotnet pack -o ./artifacts/nuget -p:Version=${nextRelease.version}"
+            }
+        ],
+        [
             "@semantic-release/git",
             {
                 "assets": [
                     "CHANGELOG.md"
                 ],
-                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+                "message": "Tag release #${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }
         ]
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [1.5.0-rc.2](https://github.com/yozepi/semantic-release-dotnet/compare/v1.5.0-rc.1...v1.5.0-rc.2) (2021-11-01)
+
+
+### Features
+
+* Move dotnet pack to the semantic-release workflow. ([3a110de](https://github.com/yozepi/semantic-release-dotnet/commit/3a110de74265a18c77bab163605e27bef3686ff9))
+
+# [1.5.0-rc.1](https://github.com/yozepi/semantic-release-dotnet/compare/v1.4.1-rc.1...v1.5.0-rc.1) (2021-10-30)
+
+
+### Features
+
+* nuget pack and save as artifact ([#10](https://github.com/yozepi/semantic-release-dotnet/issues/10)) ([e9143c6](https://github.com/yozepi/semantic-release-dotnet/commit/e9143c61f68e6590f01033abad053269b0f53514))
+
 ## [1.4.1-rc.1](https://github.com/yozepi/semantic-release-dotnet/compare/v1.4.0...v1.4.1-rc.1) (2021-10-29)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.0",
+        "@semantic-release/exec": "^6.0.2",
         "@semantic-release/git": "^10.0.0",
         "semantic-release": "^18.0.0"
       }
@@ -345,6 +346,26 @@
       "dev": true,
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.2.tgz",
+      "integrity": "sha512-ciaqJTHB1TFtU6C78xrgmoNI9UyfheR9+Bk6Ico7CJ7+ADOEAvUrPBKvz64UCfoWlg+SlKGTVGbFnA509wRUVw==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@semantic-release/git": {
@@ -6659,6 +6680,20 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
       "dev": true
+    },
+    "@semantic-release/exec": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.2.tgz",
+      "integrity": "sha512-ciaqJTHB1TFtU6C78xrgmoNI9UyfheR9+Bk6Ico7CJ7+ADOEAvUrPBKvz64UCfoWlg+SlKGTVGbFnA509wRUVw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      }
     },
     "@semantic-release/git": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/yozepi/semantic-release-dotnet#readme",
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.0",
+    "@semantic-release/exec": "^6.0.2",
     "@semantic-release/git": "^10.0.0",
     "semantic-release": "^18.0.0"
   }


### PR DESCRIPTION
* feat: nuget pack and save as artifact (#10)

Co-authored-by: Joe Cleland <joe.cleland@eventcore.com>

* chore(release): 1.5.0-rc.1 [skip ci]

# [1.5.0-rc.1](https://github.com/yozepi/semantic-release-dotnet/compare/v1.4.1-rc.1...v1.5.0-rc.1) (2021-10-30)

### Features

* nuget pack and save as artifact ([#10](https://github.com/yozepi/semantic-release-dotnet/issues/10)) ([e9143c6](https://github.com/yozepi/semantic-release-dotnet/commit/e9143c61f68e6590f01033abad053269b0f53514))

* feat: Move dotnet pack to the semantic-release workflow.

* chore: fix typo.

* Feature/move build and pack (#13)

* feat: Move dotnet pack to the semantic-release workflow.

* chore: fix typo.

* chore: fix typo.

* chore: Add /exec to the yaml file.

Co-authored-by: Joe Cleland <joe.cleland@eventcore.com>

* Tag release #1.5.0-rc.2 [skip ci]

# [1.5.0-rc.2](https://github.com/yozepi/semantic-release-dotnet/compare/v1.5.0-rc.1...v1.5.0-rc.2) (2021-11-01)

### Features

* Move dotnet pack to the semantic-release workflow. ([3a110de](https://github.com/yozepi/semantic-release-dotnet/commit/3a110de74265a18c77bab163605e27bef3686ff9))

Co-authored-by: Joe Cleland <joe.cleland@eventcore.com>
Co-authored-by: semantic-release-bot <semantic-release-bot@martynus.net>